### PR TITLE
fix: `typespec-ts-mode-grammar`をオリジナルのものに

### DIFF
--- a/typespec-ts-mode.el
+++ b/typespec-ts-mode.el
@@ -46,7 +46,7 @@
 (require 'c-ts-common)
 
 (defcustom typespec-ts-mode-grammar
-  '("https://github.com/ncaq/tree-sitter-typespec/" "interface-have-decorators")
+  '("https://github.com/happenslol/tree-sitter-typespec/")
   "URL or a cons cell of URL and revision.
 Configuration for downloading and installing
 the tree-sitter `typespec-ts-mode' grammar."


### PR DESCRIPTION
開発中にいじりたいだけならせっかく`defcustom`しているのだから、
こちら側の設定ファイルで変えれば良いだけの話だった。
